### PR TITLE
Define TPROC benchmarks

### DIFF
--- a/k8s/hammerdb/deployment-hammerdb.yaml
+++ b/k8s/hammerdb/deployment-hammerdb.yaml
@@ -25,3 +25,20 @@ spec:
             - "10000"
           ports:
             - containerPort: 8080
+          volumeMounts:
+            - name: vol-mariadb-conf
+              mountPath: /home/hammerdb/HammerDB-4.5/maria_ephemeral_tprocc_build.tcl
+              subPath: maria_ephemeral_tprocc_build.tcl
+            - name: vol-mariadb-conf
+              mountPath: /home/hammerdb/HammerDB-4.5/maria_ephemeral_tprocc_run.tcl
+              subPath: maria_ephemeral_tprocc_run.tcl
+            - name: vol-mariadb-conf
+              mountPath: /home/hammerdb/HammerDB-4.5/maria_tprocc_build.tcl
+              subPath: maria_tprocc_build.tcl
+            - name: vol-mariadb-conf
+              mountPath: /home/hammerdb/HammerDB-4.5/maria_tprocc_run.tcl
+              subPath: maria_tprocc_run.tcl
+      volumes:
+        - name: vol-mariadb-conf
+          configMap:
+            name: cm-mariadb-conf

--- a/k8s/hammerdb/deployment-mariadb-ephemeral.yaml
+++ b/k8s/hammerdb/deployment-mariadb-ephemeral.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mariadb-ephemeral
+  labels:
+    component: mariadb-ephemeral
+spec:
+  selector:
+    matchLabels:
+      component: mariadb-ephemeral
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        component: mariadb-ephemeral
+    spec:
+      containers:
+        - image: mariadb:10.3.34
+          name: mariadb
+          env:
+            - name: MARIADB_ROOT_PASSWORD
+              value: pass
+          ports:
+            - containerPort: 3306
+              name: mariadb
+          volumeMounts:
+            - name: vol-mariadb
+              mountPath: /var/lib/mysql
+            - name: vol-mariadb-conf
+              mountPath: /etc/mysql/my.cnf
+              subPath: my.cnf
+            - name: vol-mariadb-conf
+              mountPath: /etc/mysql/mariadb.cnf
+              subPath: mariadb.cnf
+            - name: vol-mariadb-conf
+              mountPath: /etc/mysql/conf.d/mysqld_safe_syslog.cnf
+              subPath: mysqld_safe_syslog.cnf
+      volumes:
+        - name: vol-mariadb
+          emptyDir: {}
+        - name: vol-mariadb-conf
+          configMap:
+            name: cm-mariadb-conf

--- a/k8s/hammerdb/hammerdb-scripts/maria_ephemeral_tprocc_build.tcl
+++ b/k8s/hammerdb/hammerdb-scripts/maria_ephemeral_tprocc_build.tcl
@@ -8,35 +8,23 @@ puts "SETTING CONFIGURATION"
 dbset db maria
 dbset bm TPC-C
 
-diset connection maria_host mariadb
+diset connection maria_host mariadb-ephemeral
 diset connection maria_port 3306
 
+diset tpcc maria_count_ware 1
+diset tpcc maria_num_vu 1
 diset tpcc maria_user root
 diset tpcc maria_pass pass
 diset tpcc maria_dbase tpcc
-diset tpcc maria_driver timed
-diset tpcc maria_rampup 2
-diset tpcc maria_duration 5
-diset tpcc maria_timeprofile false
+diset tpcc maria_storage_engine innodb
+diset tpcc maria_partition false 
 
 print dict
 vuset logtotemp 1
-loadscript
-puts "TEST STARTED"
-vuset vu 1
-vucreate
-tcstart
-tcstatus
-vurun
-runtimer 500
-vudestroy
-tcstop
-puts "TEST COMPLETE"
-quit
+buildschema
+waittocomplete
 
 #For Advanced configuration changes, check configuration parameters using command "print dict" in ./hammerdbcli
 
 #Command to run the script
-# ./hammerdbcli auto /dev_src/maria_tprocc_run.tcl
-
-
+# ./hammerdbcli auto /dev_src/maria_tprocc_build.tcl

--- a/k8s/hammerdb/hammerdb-scripts/maria_ephemeral_tprocc_run.tcl
+++ b/k8s/hammerdb/hammerdb-scripts/maria_ephemeral_tprocc_run.tcl
@@ -8,7 +8,7 @@ puts "SETTING CONFIGURATION"
 dbset db maria
 dbset bm TPC-C
 
-diset connection maria_host mariadb
+diset connection maria_host mariadb-ephemeral
 diset connection maria_port 3306
 
 diset tpcc maria_user root

--- a/k8s/hammerdb/kustomization.yaml
+++ b/k8s/hammerdb/kustomization.yaml
@@ -8,10 +8,12 @@ resources:
   # - bc-hammerdb.yaml
   # - is-hammerdb.yaml
   - deployment-mariadb.yaml
+  - deployment-mariadb-ephemeral.yaml
+  - deployment-hammerdb.yaml
   - ns-hammerdb.yaml
   - pvc-mariadb.yaml
   - svc-mariadb.yaml
-  - deployment-hammerdb.yaml
+  - svc-mariadb-ephemeral.yaml
 
 configMapGenerator:
   - name: cm-mariadb-conf
@@ -19,6 +21,10 @@ configMapGenerator:
       - my.cnf=mariadb-conf/etc-mysql-my.cnf
       - mariadb.cnf=mariadb-conf/etc-mysql-mariadb.cnf
       - mysqld_safe_syslog.cnf=mariadb-conf/etc-mysql-conf.d-mysqld_safe_syslog.cnf
+      - maria_ephemeral_tprocc_build.tcl=hammerdb-scripts/maria_ephemeral_tprocc_build.tcl
+      - maria_ephemeral_tprocc_run.tcl=hammerdb-scripts/maria_ephemeral_tprocc_run.tcl
+      - maria_tprocc_build.tcl=hammerdb-scripts/maria_tprocc_build.tcl
+      - maria_tprocc_run.tcl=hammerdb-scripts/maria_tprocc_run.tcl
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/k8s/hammerdb/svc-mariadb-ephemeral.yaml
+++ b/k8s/hammerdb/svc-mariadb-ephemeral.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mariadb-ephemeral
+spec:
+  selector:
+    component: mariadb-ephemeral
+  ports:
+    - protocol: TCP
+      port: 3306
+      targetPort: 3306


### PR DESCRIPTION
The changes made here are to flesh out the 2 TPROC tasks, one with mariadb backed by ephemeral storage and for the mariadb backed by a persisent volume.