### PR TITLE
Add SSD Deployment to HammerDB Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This will deploy the following pods:
 
     mariadb-ephemeral    - mariadb that is using the ephemeral disk for storage
     mariadb              - mariadb that is using a persistent volume for storage
+    mariadb-ssd          - mariadb that is using SSD persistent volume for storage
     hammerdb             - can run the hammerdb manually
 # To run in a kubernetes job
 Just create the job with the yaml in the top directory of the repo.  Naming convention is
@@ -23,6 +24,10 @@ To run the tprocc benchmark on mariadb backed by a persistent volume:
 To run the tprocc benchmark on mariadb backed by ephemeral storage
 
     oc create -f job-tprocc-mariadb-ephemeral.yaml	 
+
+To run the tprocc benchmark on mariadb backed by ephemeral storage
+
+    oc create -f job-tprocc-mariadb-ssd.yaml	 
 
 Creating the job will start a container to run the benchmark.  To find the correct
 container, uss:

--- a/job-tprocc-mariadb-ssd.yaml
+++ b/job-tprocc-mariadb-ssd.yaml
@@ -1,0 +1,49 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: job-tprocc-mariadb-ssd
+spec:
+  template:
+    spec:
+      initContainers:
+        - image: ghcr.io/cci-moc/k-hammer:nightly
+          name: hammerdb-build
+          imagePullPolicy: IfNotPresent
+          command:
+            - "/home/hammerdb/HammerDB-4.5/hammerdbcli"
+          args:
+            - "auto"
+            - "/home/hammerdb/HammerDB-4.5/maria_ssd_tprocc_build.tcl"
+          env:
+            - name: "TMP"
+              value: "/tmp"
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: vol-hammer-scripts
+              mountPath: /home/hammerdb/HammerDB-4.5/maria_ssd_tprocc_build.tcl
+              subPath: maria_ssd_tprocc_build.tcl
+      containers:
+        - image: ghcr.io/cci-moc/k-hammer:nightly
+          name: hammerdb-run
+          imagePullPolicy: IfNotPresent
+          command:
+            - "/home/hammerdb/HammerDB-4.5/hammerdbcli"
+          args:
+            - "auto"
+            - "/home/hammerdb/HammerDB-4.5/maria_ssd_tprocc_run.tcl"
+          env:
+            - name: "TMP"
+              value: "/tmp"
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: vol-hammer-scripts
+              mountPath: /home/hammerdb/HammerDB-4.5/maria_ssd_tprocc_run.tcl
+              subPath: maria_ssd_tprocc_run.tcl
+      volumes:
+        - name: vol-hammer-scripts
+          configMap:
+            name: cm-k-hammer
+      restartPolicy: Never
+  backoffLimit: 2

--- a/k8s/hammerdb/deployment-mariadb-ssd.yaml
+++ b/k8s/hammerdb/deployment-mariadb-ssd.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mariadb-ssd
+  labels:
+    component: mariadb-ssd
+spec:
+  selector:
+    matchLabels:
+      component: mariadb-ssd
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        component: mariadb-ssd
+    spec:
+      containers:
+        - image: mariadb:10.3.34
+          name: mariadb
+          env:
+            - name: MARIADB_ROOT_PASSWORD
+              value: pass
+          ports:
+            - containerPort: 3306
+              name: mariadb
+          volumeMounts:
+            - name: vol-mariadb
+              mountPath: /var/lib/mysql
+            - name: vol-mariadb-conf
+              mountPath: /etc/mysql/my.cnf
+              subPath: my.cnf
+            - name: vol-mariadb-conf
+              mountPath: /etc/mysql/mariadb.cnf
+              subPath: mariadb.cnf
+            - name: vol-mariadb-conf
+              mountPath: /etc/mysql/conf.d/mysqld_safe_syslog.cnf
+              subPath: mysqld_safe_syslog.cnf
+      volumes:
+        - name: vol-mariadb
+          persistentVolumeClaim:
+            claimName: pvc-mariadb-ssd
+        - name: vol-mariadb-conf
+          configMap:
+            name: cm-k-hammer

--- a/k8s/hammerdb/hammerdb-scripts/maria_ssd_tprocc_build.tcl
+++ b/k8s/hammerdb/hammerdb-scripts/maria_ssd_tprocc_build.tcl
@@ -1,0 +1,30 @@
+#!/bin/tclsh
+
+# This is moved to the env of the container as this causes hammerdb auto to fail
+# Set the path for logs directory. By Default logs are logged in /tmp
+# export TMP="/tmp"
+
+puts "SETTING CONFIGURATION"
+dbset db maria
+dbset bm TPC-C
+
+diset connection maria_host mariadb-ssd
+diset connection maria_port 3306
+
+diset tpcc maria_count_ware 1
+diset tpcc maria_num_vu 1
+diset tpcc maria_user root
+diset tpcc maria_pass pass
+diset tpcc maria_dbase tpcc
+diset tpcc maria_storage_engine innodb
+diset tpcc maria_partition false 
+
+print dict
+vuset logtotemp 1
+buildschema
+waittocomplete
+
+#For Advanced configuration changes, check configuration parameters using command "print dict" in ./hammerdbcli
+
+#Command to run the script
+# ./hammerdbcli auto /dev_src/maria_ssd_tprocc_build.tcl

--- a/k8s/hammerdb/hammerdb-scripts/maria_ssd_tprocc_run.tcl
+++ b/k8s/hammerdb/hammerdb-scripts/maria_ssd_tprocc_run.tcl
@@ -1,0 +1,99 @@
+#!/bin/tclsh
+
+# This is moved to the env of the container as this causes hammerdb auto to fail
+# Set the path for logs directory. By Default logs are logged in /tmp
+# export TMP="/tmp"
+
+# parameters that can be changed with diset:
+#
+#  connection {
+#   maria_host               = mariadb-ephemeral
+#   maria_port               = 3306
+#   maria_socket             = /tmp/mariadb.sock
+#   maria_ssl                = false
+#   maria_ssl_two_way        = false
+#   maria_ssl_linux_capath   = /etc/mysql/certs
+#   maria_ssl_windows_capath = C:\mysql\certs
+#   maria_ssl_ca             = ca-cert.pem
+#   maria_ssl_cert           = client-cert.pem
+#   maria_ssl_key            = client-key.pem
+#   maria_ssl_cipher         = server
+#  }
+#  tpcc  {
+#   maria_count_ware       = 1
+#   maria_num_vu           = 1
+#   maria_user             = root
+#   maria_pass             = pass
+#   maria_dbase            = tpcc
+#   maria_storage_engine   = innodb
+#   maria_partition        = false
+#   maria_prepared         = false
+#   maria_total_iterations = 10000000
+#   maria_raiseerror       = false
+#   maria_keyandthink      = false
+#   maria_driver           = test
+#   maria_rampup           = 2
+#   maria_duration         = 5
+#   maria_allwarehouse     = false
+#   maria_timeprofile      = false
+#   maria_async_scale      = false
+#   maria_async_client     = 10
+#   maria_async_verbose    = false
+#   maria_async_delay      = 1000
+#   maria_connect_pool     = false
+#  }
+# 
+# parameters that can be changed with vuset:
+#
+#  Virtual Users = 1
+#  User Delay(ms) = 500
+#  Repeat Delay(ms) = 500
+#  Iterations = 1
+#  Show Output = 1
+#  Log Output = 0
+#  Unique Log Name = 0
+#  No Log Buffer = 0
+#  Log Timestamps = 0
+#
+# parameters that can be changed with tcset:
+#  tc_refresh_rate    = 10
+#  tc_log_to_temp     = 0
+#  tc_unique_log_name = 0
+#  tc_log_timestamps  = 0
+
+puts "SETTING CONFIGURATION"
+dbset db maria
+dbset bm TPC-C
+
+diset connection maria_host mariadb-ssd
+diset connection maria_port 3306
+
+diset tpcc maria_user root
+diset tpcc maria_pass pass
+diset tpcc maria_dbase tpcc
+diset tpcc maria_driver timed
+diset tpcc maria_rampup 2
+diset tpcc maria_duration 5
+diset tpcc maria_timeprofile false
+
+print dict
+vuset logtotemp 1
+loadscript
+puts "TEST STARTED"
+vuset vu 1
+vucreate
+tcstart
+tcstatus
+vurun
+runtimer 500
+vudestroy
+tcstop
+puts "TEST COMPLETE"
+quit
+
+#For Advanced configuration changes, check configuration parameters using command "print dict" in ./hammerdbcli
+
+#Command to run the script
+# ./hammerdbcli auto /dev_src/maria_tprocc_run.tcl
+
+

--- a/k8s/hammerdb/kustomization.yaml
+++ b/k8s/hammerdb/kustomization.yaml
@@ -2,17 +2,18 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 commonLabels:
   app: hammerdb
-namespace: hammerdb
 
 resources:
   # - bc-hammerdb.yaml
   # - is-hammerdb.yaml
   - deployment-mariadb.yaml
+  - deployment-mariadb-ssd.yaml
   - deployment-mariadb-ephemeral.yaml
   - deployment-hammerdb.yaml
-  - ns-hammerdb.yaml
   - pvc-mariadb.yaml
+  - pvc-mariadb-ssd.yaml
   - svc-mariadb.yaml
+  - svc-mariadb-ssd.yaml
   - svc-mariadb-ephemeral.yaml
 
 configMapGenerator:
@@ -25,6 +26,8 @@ configMapGenerator:
       - maria_ephemeral_tprocc_run.tcl=hammerdb-scripts/maria_ephemeral_tprocc_run.tcl
       - maria_tprocc_build.tcl=hammerdb-scripts/maria_tprocc_build.tcl
       - maria_tprocc_run.tcl=hammerdb-scripts/maria_tprocc_run.tcl
+      - maria_ssd_tprocc_build.tcl=hammerdb-scripts/maria_ssd_tprocc_build.tcl
+      - maria_ssd_tprocc_run.tcl=hammerdb-scripts/maria_ssd_tprocc_run.tcl
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/k8s/hammerdb/ns-hammerdb.yaml
+++ b/k8s/hammerdb/ns-hammerdb.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: hammerdb

--- a/k8s/hammerdb/pvc-mariadb-ssd.yaml
+++ b/k8s/hammerdb/pvc-mariadb-ssd.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-mariadb-ssd
+spec:
+  storageClassName: ocs-external-storagecluster-ceph-rbd-ssd
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi

--- a/k8s/hammerdb/pvc-mariadb.yaml
+++ b/k8s/hammerdb/pvc-mariadb.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: pvc-mariadb
 spec:
+  storageClassName: ocs-external-storagecluster-ceph-rbd
   accessModes:
     - ReadWriteOnce
   resources:

--- a/k8s/hammerdb/svc-mariadb-ssd.yaml
+++ b/k8s/hammerdb/svc-mariadb-ssd.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mariadb-ssd
+spec:
+  selector:
+    component: mariadb-ssd
+  ports:
+    - protocol: TCP
+      port: 3306
+      targetPort: 3306


### PR DESCRIPTION
This PR adds an additional pod `mariadb-ssd` for running hammerdb against it. The structure follows the same pattern as the HDD and ephemeral deployments which were already existent. This is what was used for the results in [this issue](https://github.com/OCP-on-NERC/operations/issues/91)

In addition, this PR removes the namespace manifest, as I find it more flexible to specify the namespace in the CLI before deployment.

I've also hardcoded the storage class for the mariadb pvc to NESE HDD, it was not specified before.